### PR TITLE
Don't parse response on code 204

### DIFF
--- a/lib/xhttp.js
+++ b/lib/xhttp.js
@@ -125,7 +125,7 @@ module.exports = function (promiseConstructor) {
       // Attach a success listener
       xhr.onload = function() {
         if (successful(xhr)) {
-          resolve(parseResponse(xhr, true))
+          resolve(xhr.status === 204 ? null : parseResponse(xhr, true))
         } else {
           reject(parseResponse(xhr))
         }


### PR DESCRIPTION
When server return code 204(No Content) lib must not parse content
because it throw error

More info about 204
http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5