### PR TITLE
wrap native promise into its own include to keep ES6 imports sane

### DIFF
--- a/native.js
+++ b/native.js
@@ -1,0 +1,9 @@
+'use strict'
+
+/**
+ * expose xhttp using native Promise implementation, useful if targetting
+ * only browsers with native Promises, if your application already Polyfills
+ * Promise, or if your build tool will be shimming or transforming `Promise`
+ */
+
+module.exports = require('./lib/xhttp')(Promise)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xhttp",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Lightweight ajax with pluggable ES6 promises and no mandatory dependencies.",
   "author": "Mitranim",
   "main": "./lib/index.js",

--- a/readme.md
+++ b/readme.md
@@ -28,16 +28,23 @@ The bower version uses the pre-built file that exposes the global `window.xhttp`
 
 ## Initialisation
 
-To get the default version, just require it:
+To get the default version, which will use the `es6-promise` shim, just require it:
 
 ```javascript
 var xhttp = require('xhttp')
 ```
 
-This will use an ES6 promise shim. You can also make your own version. Require `xhttp/custom` and call it with a custom promise constructor:
+If your target browsers support native Promises, or the `Promise`
+constructor is provided by a polyfill or other transformation, you
+can include the native version, instead:
 
 ```javascript
-var xhttp = require('xhttp/custom')(Promise)  // native or polyfill
+var xhttp = require('xhttp/native')
+```
+
+You can also make your own version. Require `xhttp/custom` and call it with a custom promise constructor:
+
+```javascript
 var xhttp = require('xhttp/custom')(require('q').Promise)
 var xhttp = require('xhttp/custom')(require('bluebird'))
 ```


### PR DESCRIPTION
If this isn't the epitome of laziness on my part, I dunno what is, but anyway, this allows turning this:

```js
import _xhttp from 'xhttp/custom';

const xhttp = _xhttp(Promise);
```

into

```js
import xhttp from 'xhttp/native';
```